### PR TITLE
feat(workers): initial workers view, context, form, mock data

### DIFF
--- a/web-app/app/workers/layout.tsx
+++ b/web-app/app/workers/layout.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { WorkersProvider } from "@/lib/context/WorkersContext";
+
+export default function WorkersSectionLayout({ children }: { children: React.ReactNode }) {
+  return <WorkersProvider>{children}</WorkersProvider>;
+}

--- a/web-app/app/workers/new/page.tsx
+++ b/web-app/app/workers/new/page.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { EmployeeForm } from "@/components/worker/EmployeeForm";
+
+export default function NewWorkerPage() {
+  // We wrap this page in its own provider so navigation back to /workers (layout provider) still sees updates if root also wraps.
+  return (
+    <div className="p-6 space-y-8">
+      <div>
+        <h1 className="text-3xl font-semibold tracking-tight">Add New Employee</h1>
+        <p className="text-sm text-zinc-500 mt-1">Create a worker record using mock persistence.</p>
+      </div>
+  <EmployeeForm />
+    </div>
+  );
+}

--- a/web-app/components/ui/badge.tsx
+++ b/web-app/components/ui/badge.tsx
@@ -1,0 +1,44 @@
+import * as React from "react"
+import clsx from "clsx"
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?:
+    | "default"
+    | "secondary"
+    | "outline"
+    | "success"
+    | "warning"
+    | "destructive"
+    | "purple"
+}
+
+export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ className, variant = "default", ...props }, ref) => {
+    return (
+      <span
+        ref={ref}
+        className={clsx(
+          "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium",
+          "transition-colors",
+          {
+            default: "bg-zinc-900 text-zinc-50 border-transparent dark:bg-zinc-50 dark:text-zinc-900",
+            secondary:
+              "bg-zinc-100 text-zinc-800 border-transparent dark:bg-zinc-800 dark:text-zinc-100",
+            outline: "text-zinc-700 border-zinc-300 dark:text-zinc-200 dark:border-zinc-600",
+            success:
+              "bg-green-500/15 text-green-700 border-green-600/30 dark:text-green-300 dark:border-green-400/40",
+            warning:
+              "bg-amber-500/15 text-amber-700 border-amber-600/30 dark:text-amber-300 dark:border-amber-400/40",
+            destructive:
+              "bg-rose-500/15 text-rose-700 border-rose-600/40 dark:text-rose-300 dark:border-rose-400/40",
+            purple:
+              "bg-violet-500/15 text-violet-700 border-violet-600/40 dark:text-violet-300 dark:border-violet-400/40",
+          }[variant],
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+Badge.displayName = "Badge"

--- a/web-app/components/worker-overview.tsx
+++ b/web-app/components/worker-overview.tsx
@@ -1,55 +1,112 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useMemo } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import type { Worker } from "@/models/Worker"
+import { Badge } from "@/components/ui/badge"
+import type { WorkerStatus } from "@/models/Worker"
+import { useWorkers } from "@/lib/context/WorkersContext"
 
-const mockWorkers: Worker[] = [
-  {
-    name: "Jaan Tamm",
-    assignedShifts: [
-      { type: "Hommik", length: 8 },
-      { type: "Õhtu", length: 8 },
-    ],
-  },
-  { name: "Mari Mets", assignedShifts: [{ type: "Öö", length: 10 }] },
-  {
-    name: "Peeter Kask",
-    assignedShifts: [
-      { type: "Päev", length: 6 },
-      { type: "Õhtu", length: 8 },
-    ],
-  },
-]
+interface StatusMeta {
+  label: string
+  variant: "success" | "warning" | "destructive" | "secondary"
+}
+const statusMeta: Record<WorkerStatus, StatusMeta> = {
+  active: { label: "Active", variant: "success" },
+  leave: { label: "Leave", variant: "warning" },
+  inactive: { label: "Inactive", variant: "secondary" },
+}
 
 export function WorkerOverview() {
-  const [workers, setWorkers] = useState<Worker[]>([])
+  const { workers } = useWorkers()
+  const [search, setSearch] = useState("")
+  const [statusFilter, setStatusFilter] = useState<WorkerStatus | "all">("all")
 
-  useEffect(() => {
-    setWorkers(mockWorkers)
-  }, [])
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase()
+    return workers.filter((w) => {
+      if (statusFilter !== "all" && w.status !== statusFilter) return false
+      if (!term) return true
+      return (
+        w.name.toLowerCase().includes(term) ||
+        w.role.toLowerCase().includes(term) ||
+        w.assignedShifts.some((s) => s.type.toLowerCase().includes(term))
+      )
+    })
+  }, [workers, search, statusFilter])
 
   return (
-    <Card className="w-full max-w-4xl">
-      <CardHeader>
-        <CardTitle>Töötajad</CardTitle>
+    <Card className="w-full">
+      <CardHeader className="space-y-4">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <CardTitle className="text-2xl">Employees</CardTitle>
+          <div className="flex flex-col sm:flex-row gap-2 w-full md:w-auto">
+            <input
+              placeholder="Search name, role or shift..."
+              className="flex-1 md:w-64 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-violet-500 dark:bg-zinc-800 dark:border-zinc-700"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            <select
+              aria-label="Status filter"
+              className="rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm shadow-sm dark:bg-zinc-800 dark:border-zinc-700"
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as WorkerStatus | "all")}
+            >
+              <option value="all">All Statuses</option>
+              <option value="active">Active</option>
+              <option value="leave">Leave</option>
+              <option value="inactive">Inactive</option>
+            </select>
+            <a
+              href="/workers/new"
+              className="inline-flex items-center justify-center rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-violet-500 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2"
+            >
+              Add Employee
+            </a>
+          </div>
+        </div>
       </CardHeader>
-      <CardContent>
+      <CardContent className="p-0">
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Nimi</TableHead>
-              <TableHead>Määratud Vahetused</TableHead>
+              <TableHead className="w-[180px]">Name</TableHead>
+              <TableHead className="w-[140px]">Role</TableHead>
+              <TableHead className="w-[120px]">Status</TableHead>
+              <TableHead>Assigned Shifts</TableHead>
+              <TableHead className="hidden md:table-cell w-[200px]">Contact</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {workers.map((worker, index) => (
-              <TableRow key={index}>
-                <TableCell>{worker.name}</TableCell>
-                <TableCell>{worker.assignedShifts.map((shift) => shift.type).join(", ")}</TableCell>
+            {filtered.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={5} className="py-10 text-center text-sm text-zinc-500">
+                  No employees match your search.
+                </TableCell>
               </TableRow>
-            ))}
+            )}
+            {filtered.map((worker) => {
+                const meta = statusMeta[worker.status]
+                return (
+                  <TableRow key={worker.id}>
+                    <TableCell className="font-medium">{worker.name}</TableCell>
+                    <TableCell>
+                      <Badge variant="purple">{worker.role}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={meta.variant}>{meta.label}</Badge>
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {worker.assignedShifts.map((s) => s.type).join(", ") || "—"}
+                    </TableCell>
+                    <TableCell className="hidden md:table-cell text-xs text-zinc-600 dark:text-zinc-300">
+                      {worker.email && <div>{worker.email}</div>}
+                      {worker.phone && <div>{worker.phone}</div>}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
           </TableBody>
         </Table>
       </CardContent>

--- a/web-app/components/worker/EmployeeForm.tsx
+++ b/web-app/components/worker/EmployeeForm.tsx
@@ -1,0 +1,152 @@
+"use client";
+import React, { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useWorkers } from "@/lib/context/WorkersContext";
+import type { WorkerRole, WorkerStatus } from "@/models/Worker";
+import { Badge } from "@/components/ui/badge";
+
+const roles: WorkerRole[] = ["Chef", "Manager", "Waiter", "Cleaner", "Other"];
+const statuses: WorkerStatus[] = ["active", "leave", "inactive"];
+
+interface FieldErrors { [k: string]: string | undefined }
+
+export function EmployeeForm() {
+  const { addWorker } = useWorkers();
+  const router = useRouter();
+  const [form, setForm] = useState({
+    name: "",
+    role: roles[0],
+    status: statuses[0],
+    email: "",
+    phone: "",
+    shifts: "",
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [errors, setErrors] = useState<FieldErrors>({});
+
+  function validate(): boolean {
+    const e: FieldErrors = {};
+    if (!form.name.trim()) e.name = "Name required";
+    if (form.email && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(form.email)) e.email = "Invalid email";
+    if (form.phone && form.phone.replace(/\D/g, "").length < 7) e.phone = "Phone too short";
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  }
+
+  async function onSubmit(ev: React.FormEvent) {
+    ev.preventDefault();
+    if (!validate()) return;
+    setSubmitting(true);
+    try {
+      const assigned = form.shifts
+        .split(",")
+        .map(s => s.trim())
+        .filter(Boolean)
+        .map(type => ({ type, length: 0 }));
+      addWorker({
+        name: form.name.trim(),
+        role: form.role as WorkerRole,
+        status: form.status as WorkerStatus,
+        email: form.email || undefined,
+        phone: form.phone || undefined,
+        assignedShifts: assigned,
+      });
+      router.push("/workers");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function update<K extends keyof typeof form>(key: K, value: (typeof form)[K]) {
+    setForm(prev => ({ ...prev, [key]: value }));
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6 max-w-2xl">
+      <div>
+        <label className="block text-sm font-medium mb-1">Name *</label>
+        <input
+          className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 dark:bg-zinc-800 dark:border-zinc-700"
+          value={form.name}
+          onChange={e => update("name", e.target.value)}
+          placeholder="Employee name"
+        />
+        {errors.name && <p className="mt-1 text-xs text-rose-600">{errors.name}</p>}
+      </div>
+      <div className="grid sm:grid-cols-2 gap-6">
+        <div>
+          <label className="block text-sm font-medium mb-1">Role</label>
+          <select
+            className="w-full rounded-md border border-zinc-300 bg-white px-2 py-2 text-sm dark:bg-zinc-800 dark:border-zinc-700"
+            value={form.role}
+            onChange={e => update("role", e.target.value as WorkerRole)}
+          >
+            {roles.map(r => <option key={r}>{r}</option>)}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Status</label>
+          <select
+            className="w-full rounded-md border border-zinc-300 bg-white px-2 py-2 text-sm dark:bg-zinc-800 dark:border-zinc-700"
+            value={form.status}
+            onChange={e => update("status", e.target.value as WorkerStatus)}
+          >
+            {statuses.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </div>
+      </div>
+      <div className="grid sm:grid-cols-2 gap-6">
+        <div>
+          <label className="block text-sm font-medium mb-1">Email</label>
+          <input
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 dark:bg-zinc-800 dark:border-zinc-700"
+            value={form.email}
+            onChange={e => update("email", e.target.value)}
+            placeholder="name@example.com"
+            type="email"
+          />
+          {errors.email && <p className="mt-1 text-xs text-rose-600">{errors.email}</p>}
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Phone</label>
+          <input
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 dark:bg-zinc-800 dark:border-zinc-700"
+            value={form.phone}
+            onChange={e => update("phone", e.target.value)}
+            placeholder="+372..."
+          />
+          {errors.phone && <p className="mt-1 text-xs text-rose-600">{errors.phone}</p>}
+        </div>
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Assigned Shifts (comma separated)</label>
+        <input
+          className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 dark:bg-zinc-800 dark:border-zinc-700"
+          value={form.shifts}
+          onChange={e => update("shifts", e.target.value)}
+          placeholder="Morning, Evening"
+        />
+        <p className="mt-1 text-xs text-zinc-500">Just labels for now; will map to real shift IDs later.</p>
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex items-center rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-violet-500 disabled:opacity-50"
+        >
+          {submitting ? "Saving..." : "Save Employee"}
+        </button>
+        <button
+          type="button"
+            onClick={() => router.back()}
+          className="inline-flex items-center rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium hover:bg-zinc-50 dark:bg-zinc-800 dark:border-zinc-700 dark:hover:bg-zinc-700"
+        >
+          Cancel
+        </button>
+      </div>
+      <div className="pt-4 text-xs text-zinc-500 flex flex-wrap gap-2">
+        {roles.map(r => <Badge key={r} variant="outline">{r}</Badge>)}
+      </div>
+    </form>
+  );
+}

--- a/web-app/lib/context/WorkersContext.tsx
+++ b/web-app/lib/context/WorkersContext.tsx
@@ -1,0 +1,41 @@
+"use client";
+import React, { createContext, useContext, useState, useCallback, ReactNode } from "react";
+import type { Worker, WorkerRole, WorkerStatus } from "@/models/Worker";
+import { mockWorkers } from "@/mocks/data/workers";
+
+interface WorkersContextValue {
+  workers: Worker[];
+  addWorker: (input: Omit<Worker, "id" | "assignedShifts"> & { assignedShifts?: Worker["assignedShifts"] }) => Worker;
+}
+
+const WorkersContext = createContext<WorkersContextValue | undefined>(undefined);
+
+export function WorkersProvider({ children }: { children: ReactNode }) {
+  const [workers, setWorkers] = useState<Worker[]>(() => mockWorkers);
+
+  const addWorker = useCallback<WorkersContextValue["addWorker"]>((input) => {
+    const worker: Worker = {
+      id: (globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)),
+      assignedShifts: input.assignedShifts ?? [],
+      name: input.name,
+      role: input.role as WorkerRole,
+      status: input.status as WorkerStatus,
+      email: input.email,
+      phone: input.phone,
+    };
+    setWorkers((prev) => [worker, ...prev]);
+    return worker;
+  }, []);
+
+  return (
+    <WorkersContext.Provider value={{ workers, addWorker }}>
+      {children}
+    </WorkersContext.Provider>
+  );
+}
+
+export function useWorkers() {
+  const ctx = useContext(WorkersContext);
+  if (!ctx) throw new Error("useWorkers must be used within WorkersProvider");
+  return ctx;
+}

--- a/web-app/mocks/data/workers.ts
+++ b/web-app/mocks/data/workers.ts
@@ -1,0 +1,41 @@
+import type { Worker } from "@/models/Worker"
+
+export const mockWorkers: Worker[] = [
+  {
+    id: "w1",
+    name: "Jan Tamm",
+    role: "Chef",
+    status: "active",
+    email: "jan.tamm@example.com",
+    phone: "+3725551001",
+    assignedShifts: [
+      { type: "Morning", length: 8 },
+      { type: "Evening", length: 8 },
+    ],
+  },
+  {
+    id: "w2",
+    name: "Mari Forest",
+    role: "Waiter",
+    status: "leave",
+    email: "mari.forest@example.com",
+    phone: "+3725551002",
+    assignedShifts: [{ type: "Night", length: 10 }],
+  },
+  {
+    id: "w3",
+    name: "Peter Birch",
+    role: "Waiter",
+    status: "active",
+    email: "peter.birch@example.com",
+    phone: "+3725551003",
+    assignedShifts: [
+      { type: "Day", length: 6 },
+      { type: "Evening", length: 8 },
+    ],
+  },
+]
+
+export function fetchMockWorkers(delayMs = 250): Promise<Worker[]> {
+  return new Promise((resolve) => setTimeout(() => resolve(mockWorkers), delayMs))
+}

--- a/web-app/models/Worker.ts
+++ b/web-app/models/Worker.ts
@@ -1,6 +1,14 @@
 import { Shift } from "./Shift"
 
+export type WorkerStatus = "active" | "inactive" | "leave"
+export type WorkerRole = "Chef" | "Manager" | "Waiter" | "Cleaner" | "Other"
+
 export interface Worker {
+  id: string
   name: string
+  role: WorkerRole
+  status: WorkerStatus
+  email?: string
+  phone?: string
   assignedShifts: Shift[]
 }


### PR DESCRIPTION
- Adds a workers page showing mock employees with search and status filter.

- Includes an Add Employee form at /workers/new that updates the in‑memory list (not saved after refresh). 

